### PR TITLE
fix: `NameError` on too many failed connection attempts

### DIFF
--- a/lib/ps_utilities/connection.rb
+++ b/lib/ps_utilities/connection.rb
@@ -98,7 +98,7 @@ module PsUtilities
           count += 1
           retry
         else
-          { error: "no response (timeout) from URL: #{url}"  }
+          { error: "no response (timeout) from URL: #{ps_url}"  }
         end
       end
     end


### PR DESCRIPTION
fixes https://github.com/LAS-IT/ps_utilities/issues/3

This changes a variable name to address the above-referenced issue.